### PR TITLE
modified add_theme to color plots with nmfspalette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,3 +30,5 @@ Imports:
     stringr,
     tidyr,
     utils
+  Remotes:
+    nmfs-fish-tools/nmfspalette

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     flextable,
     ggplot2,
     naniar,
+    nmfspalette,
     stringr,
     tidyr,
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,10 +19,9 @@ Description: Creates exploratory and finished tables and figures for stock asses
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     dplyr,
-    extrafont,
     flextable,
     ggplot2,
     naniar,

--- a/R/add_theme.R
+++ b/R/add_theme.R
@@ -33,7 +33,12 @@ add_theme <- function(x) {
         panel.grid = ggplot2::element_blank(),
         panel.border = ggplot2::element_rect(colour = "black", fill = NA, linewidth = 0.5)
         # text = ggplot2::element_text(size = 12, family = "Cambria")
-      )
+      ) +
+      # add nmfs color palette (palette will be default)
+      # I believe including both functions is fine and will
+      # works regardless of the type of plot (one won't be used)
+      nmfspalette::scale_color_nmfs() +
+      nmfspalette::scale_fill_nmfs()
     # Determining how to treat a legend if there is one
     # check if one is present
     # check_for_legend <- function(x) {

--- a/man/plot_recruitment.Rd
+++ b/man/plot_recruitment.Rd
@@ -6,11 +6,16 @@
 \usage{
 plot_recruitment(
   dat,
-  model,
+  model = "standard",
   params = FALSE,
   params_only = FALSE,
   units = c(sb = "metric tons", recruitment = "metric tons"),
+  recruitment_units = "metric tons",
+  spawning_biomass_units = "metric tons",
+  scaled = FALSE,
+  scale_amount = NULL,
   show_warnings = FALSE,
+  end_year = NULL,
   return = "recruitment"
 )
 }
@@ -30,9 +35,19 @@ are options for plotting spawning biomass.}
 or are different for SB and R, then report them here starting with SB units
 and following with R units.}
 
+\item{recruitment_units}{units for recruitment}
+
+\item{spawning_biomass_units}{units of spawning biomass if different from biomass}
+
+\item{scaled}{T/F; indicate whether the output values for biomass and recruitment are scaled}
+
+\item{scale_amount}{indicate the exact amount of scale (i.e. 1000)}
+
 \item{show_warnings}{Include warnings? Default FALSE}
 
-\item{return}{Default returns recruitment over time. Options to display stock recruitment curve/recruitment fit}
+\item{end_year}{last year of assessment}
+
+\item{return}{Default returns recruitment over time. Options to display recruitment time series, stock recruitment curve, or recruitment fit}
 }
 \value{
 A series of plots are exported including recruitment over time with R0

--- a/man/plot_spawning_biomass.Rd
+++ b/man/plot_spawning_biomass.Rd
@@ -6,12 +6,16 @@
 \usage{
 plot_spawning_biomass(
   dat,
-  model = c("SS3", "BAM", "ASAP", "AMAK", "WHAM"),
-  refpts = FALSE,
+  model = c("SS3", "BAM", "ASAP", "AMAK", "WHAM", "standard"),
   show_warnings = FALSE,
   units = NULL,
+  biomass_units = NULL,
+  spawning_biomass_units = NULL,
+  scaled = FALSE,
+  scale_amount = 1000,
   ref_line = c("target", "MSY", "msy", "unfished"),
-  endyr = NULL
+  end_year = NULL,
+  relative = FALSE
 )
 }
 \arguments{
@@ -22,25 +26,32 @@ other associated metrics.}
 Currently, only stock synthesis (SS3) and Beaufort Assessment Model (BAM)
 are options for plotting spawning biomass.}
 
-\item{refpts}{Output a dataframe of reference points for spawning biomass
-rather than plot. Default is FALSE.}
-
 \item{show_warnings}{Option to suppress warnings}
 
 \item{units}{If units are not available in the output file or are not the
 default of metric tons, then state the units of spawning biomass applicable
 to the stock. For plotting purposes, spawning biomass is divided by 1000.}
 
+\item{biomass_units}{units for biomass}
+
+\item{spawning_biomass_units}{units of spawning biomass if different from biomass}
+
+\item{scaled}{TRUE/FALSE; indicate whether the output values for biomass and recruitment are scaled}
+
+\item{scale_amount}{indicate the exact amount of scale (i.e. 1000)}
+
 \item{ref_line}{choose with reference point to plot a reference line and use
 in relative sb calculations}
 
-\item{endyr}{input the end year of the stock assessment data (not including
-projections). This parameter will be depricated once the output converter is fully developed.}
+\item{end_year}{input the end year of the stock assessment data (not including
+projections). This parameter will be deprecated once the output converter is fully developed.}
+
+\item{relative}{Plot relative spawning biomass. Ref line indicates which reference point to use}
 }
 \value{
 Plot spawning biomass from a stock assessment model as found in a NOAA
 stock assessment report. Units of spawning biomass can either be manually added
-or will be extracted from the provided file if possible.
+or will be extracted from the provided file if possible. In later releases, model will not
 }
 \description{
 Plot Spawning Biomass


### PR DESCRIPTION
In my testing, adding

```
  nmfspalette::scale_color_nmfs() +
  nmfspalette::scale_fill_nmfs() 
```

to the existing plot code worked out fine, regardless of whether the plot is a scatterplot, line plot, etc. But this may fail with other types of plots.