### PR TITLE
[HOTFIX]: label names in filter data tolower

### DIFF
--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -645,7 +645,7 @@ filter_data <- function(
       model_label = TRUE
     }
     data <- data |>
-      # make sure all labels only contain lower case
+      # make sure all labels are lowercase and spaces are replaced with underscores
       dplyr::mutate(
         label = tolower(gsub(" ", "_", label))
       ) |>


### PR DESCRIPTION
## The Issue

There was an issue with FIMS using this when they have non standard names and a step in the function was causing label names not being found due to issues with upper and lower case. This PR adds a step before the data is filtered to change all labels to lowercase. This method reduces having to use other string variations to find the specified quantity.

## What was done

- edit data so labels are all lowercase to match lookback for label arg