### PR TITLE
Address bug found in #179

### DIFF
--- a/R/convert_output.R
+++ b/R/convert_output.R
@@ -1056,8 +1056,23 @@ convert_output <- function(
               row <- row[row != "XX"]
               df1 <- df1[, -loc_xx]
             }
+            
+            # check if the headers make sense
+            # this is a temporary fix to a specific bug
+            # I have seen this issue in the past and I am not sure how to recognize this generally
+            if (any(parm_sel == "AGE_SELEX" & c("1","2", "3") %notin% row)) {
+              rownum <- prodlim::row.match(row, df1)
+              # Subset data frame
+              df1 <- df1[-c(1:rownum), ]
+              cols_to_keep <- which(sapply(df1, function(x) !all(is.na(x))))
+              df1 <- df1 |> dplyr::select(dplyr::all_of(c(names(cols_to_keep))))
+              df2 <- df1[stats::complete.cases(df1), ]
+              row <- df2[1, ]
+            }
+            
             # make row the header names for first df
             colnames(df1) <- row
+            
             # find row number that matches 'row'
             rownum <- prodlim::row.match(row, df1)
             # Subset data frame

--- a/R/convert_output.R
+++ b/R/convert_output.R
@@ -1057,6 +1057,7 @@ convert_output <- function(
               df1 <- df1[, -loc_xx]
             }
             
+            # TODO: apply this next if statement to a general process so it's part of the standard cleaning
             # check if the headers make sense
             # this is a temporary fix to a specific bug
             # I have seen this issue in the past and I am not sure how to recognize this generally


### PR DESCRIPTION
A bug was identified in convert_output() in #179 where the converter fails when the headers are not properly created. 

This was occurring during the "AGE_SELEX" module in SS3. This PR creates a fix that was tested and worked for her examples.

Needs
- more testing on the remainder of test Report.sso to verify this isn't function breaking
- Future development to generalize this fix to id any other instances this occurs and fixes them in the same way

Note: this is being merged into revamped-tables branch rather than a hotfix to main because (1) revamped-tables will be merged soon and (2) I investigated and fixed this bug while on the revamped-tables branch and moved these changes to a new branch so this branch for the PR is not aligned with main.