### PR TITLE
[Fix] plot_spawning_biomass when user wants to use DERIVED_QUANTITIES from SS3

### DIFF
--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -86,7 +86,7 @@ plot_fishing_mortality <- function(
   final <- reference_line(
     plot = plt,
     dat = dat,
-    era = "time",
+    # era = "time",
     label_name = "fishing_mortality",
     reference = ref_line,
     relative = relative,

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -197,15 +197,15 @@ plot_spawning_biomass <- function(
     ylab = spawning_biomass_label,
     group = group,
     # add check in case facet is returned as character(0)
-    facet = if (length(facet) > 0) facet else NULL,
-    ...
+    facet = if (length(facet) > 0) facet else NULL#,
+    # ...
   )
   # Add reference line
   # getting data set - an ifelse statement in the fxn wasn't working
   final <- reference_line(
     plot = plt,
     dat = rp_dat,
-    era = era,
+    # era = era,
     label_name = "spawning_biomass",
     reference = ref_line,
     relative = relative,
@@ -213,25 +213,26 @@ plot_spawning_biomass <- function(
   ) + theme_noaa()
 
   # Plot vertical lines if era is not filtering
-  if (is.null(era)) {
-    # Find unique era
-    eras <- unique(plot_data$era)
-    if (length(eras) > 1) {
-      year_vlines <- c()
-      for (i in 2:length(eras)) {
-        erax <- plot_data |>
-          dplyr::filter(era == eras[i]) |>
-          dplyr::pull(year) |>
-          min(na.rm = TRUE)
-        year_vlines <- c(year_vlines, erax)
-      }
-    }
-    final <- final +
-      ggplot2::geom_vline(
-        xintercept = year_vlines,
-        color = "#999999"
-      )
-  }
+  # Turning this out because I don't think it's relevant
+  # if (is.null(era)) {
+  #   # Find unique era
+  #   eras <- unique(plot_data$era)
+  #   if (length(eras) > 1) {
+  #     year_vlines <- c()
+  #     for (i in 2:length(eras)) {
+  #       erax <- plot_data |>
+  #         dplyr::filter(era == eras[i]) |>
+  #         dplyr::pull(year) |>
+  #         min(na.rm = TRUE)
+  #       year_vlines <- c(year_vlines, erax)
+  #     }
+  #   }
+  #   final <- final +
+  #     ggplot2::geom_vline(
+  #       xintercept = year_vlines,
+  #       color = "#999999"
+  #     )
+  # }
 
   ### Make RDA ----
   if (make_rda) {

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -197,8 +197,8 @@ plot_spawning_biomass <- function(
     ylab = spawning_biomass_label,
     group = group,
     # add check in case facet is returned as character(0)
-    facet = if (length(facet) > 0) facet else NULL#,
-    # ...
+    facet = if (length(facet) > 0) facet else NULL,
+    ...
   )
   # Add reference line
   # getting data set - an ifelse statement in the fxn wasn't working

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -199,7 +199,7 @@ plot_timeseries <- function(
     )
 
   # Remove legend if no group is selected
-  if (is.null(group) & is.data.frame(dat) & any("label" %in% unique(dat$model))) {
+  if (is.null(group) & is.data.frame(dat) & any("label" %in% unique(dat$model)) | length(unique(dat$model)) == 1) {
     final <- final + ggplot2::theme(legend.position = "none")
   }
 

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -145,11 +145,20 @@ plot_timeseries <- function(
     ) +
       ggplot2::theme(legend.title = ggplot2::element_blank())
   } else {
-    color_lab <- ifelse(length(unique(dat$model)) > 1, "Model", cap_first_letter(group))
+    if (length(unique(dat$model)) > 1) {
+      color_lab <- "Model"
+    } else {
+      if(!is.null(group)) {
+        color_lab <- group
+      } else {
+        color_lab <- NULL
+      }
+    }
+    # color_lab <- ifelse(length(unique(dat$model)) > 1, "Model", group)
     labs <- plot + ggplot2::labs(
       x = xlab,
       y = ylab,
-      color = color_lab,
+      color = cap_first_letter(color_lab),
       linetype = cap_first_letter(group),
       fill = cap_first_letter(group),
       shape = cap_first_letter(group)
@@ -190,7 +199,7 @@ plot_timeseries <- function(
     )
 
   # Remove legend if no group is selected
-  if (is.null(group) & is.data.frame(dat) & any(is.na(unique(dat$model)))) {
+  if (is.null(group) & is.data.frame(dat) & any("label" %in% unique(dat$model))) {
     final <- final + ggplot2::theme(legend.position = "none")
   }
 

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -535,7 +535,7 @@ reference_line <- function(
       ggplot2::annotate(
         geom = "text",
         # TODO: need to change this for general process
-        x = as.numeric(max(dat$year[dat$era == era_name], na.rm = TRUE)), # - as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE))/200,
+        x = as.numeric(max(ggplot2::ggplot_build(plot)@data[[2]][["x"]], na.rm = TRUE)), # - as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE))/200,
         y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
         label = glue::glue("{stringr::str_replace_all(label_name, '_', '~')}[{reference}]"), # list(bquote(label_name[.(reference)])),
         parse = TRUE,

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -524,25 +524,25 @@ reference_line <- function(
     # )
     plot
   } else {
-  plot +
-    ggplot2::geom_hline(
-      # ggplot2::aes(
-      yintercept = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
-      # ),
-      color = "black",
-      linetype = "dashed"
-    ) +
-    ggplot2::annotate(
-      geom = "text",
-      # TODO: need to change this for general process
-      x = as.numeric(max(ggplot2::ggplot_build(plot)@data[[2]][["x"]], na.rm = TRUE)), # - as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE))/200,
-      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
-      label = glue::glue("{label_name}[{reference}]"), # list(bquote(label_name[.(reference)])),
-      parse = TRUE,
-      hjust = 1,
-      vjust = 0,
-      size = 5 # this is not foolproof
-    )
+    plot +
+      ggplot2::geom_hline(
+        # ggplot2::aes(
+        yintercept = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+        # ),
+        color = "black",
+        linetype = "dashed"
+      ) +
+      ggplot2::annotate(
+        geom = "text",
+        # TODO: need to change this for general process
+        x = as.numeric(max(dat$year[dat$era == era_name], na.rm = TRUE)), # - as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE))/200,
+        y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+        label = glue::glue("{stringr::str_replace_all(label_name, '_', '~')}[{reference}]"), # list(bquote(label_name[.(reference)])),
+        parse = TRUE,
+        hjust = 1,
+        vjust = 0,
+        size = 5 # this is not foolproof
+      )
   }
 }
 

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -114,9 +114,9 @@ plot_timeseries <- function(
                 group_var
               }
             }
-          )#,
+          ),
           # linewidth = 1.0,
-          # ...
+          ...
         )
     },
     "area" = {

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -89,7 +89,13 @@ plot_timeseries <- function(
             x = .data[[x]],
             ymin = estimate_lower,
             ymax = estimate_upper,
-            fill = interaction(model, group_var)
+            fill = {
+              if(length(unique(.data[["model"]])) > 1) {
+                interaction(model, group_var)
+              } else {
+                group_var
+              }
+            }
           ),
           alpha = 0.3
         ) +
@@ -101,10 +107,16 @@ plot_timeseries <- function(
             y = .data[[y]],
             # linetype = group_var,
             # linetype = ifelse(!is.null(group), group_var, "solid"),
-            color = interaction(model, group_var)
-          ),
+            color = {
+              if(length(unique(.data[["model"]])) > 1) {
+                interaction(model, group_var)
+              } else {
+                group_var
+              }
+            }
+          )#,
           # linewidth = 1.0,
-          ...
+          # ...
         )
     },
     "area" = {
@@ -133,10 +145,11 @@ plot_timeseries <- function(
     ) +
       ggplot2::theme(legend.title = ggplot2::element_blank())
   } else {
+    color_lab <- ifelse(length(unique(dat$model)) > 1, "Model", cap_first_letter(group))
     labs <- plot + ggplot2::labs(
       x = xlab,
       y = ylab,
-      color = "Model",
+      color = color_lab,
       linetype = cap_first_letter(group),
       fill = cap_first_letter(group),
       shape = cap_first_letter(group)
@@ -151,16 +164,15 @@ plot_timeseries <- function(
       # return plot if option beyond line and point for now
       labs
     )
-  }
-  if (length(unique(dat$model)) == 1) {
-    labs <- switch(geom,
-      "line" = labs + ggplot2::guides(color = "none"),
-      "point" = labs + ggplot2::guides(color = "none"),
-      "area" = labs + ggplot2::guides(fill = "none"),
-      # return plot if option beyond line and point for now
-      labs
-    )
-  }
+  } # else if (length(unique(dat$model)) == 1) {
+  #   labs <- switch(geom,
+  #     "line" = labs + ggplot2::guides(color = "none"),
+  #     "point" = labs + ggplot2::guides(color = "none"),
+  #     "area" = labs + ggplot2::guides(fill = "none"),
+  #     # return plot if option beyond line and point for now
+  #     labs
+  #   )
+  # }
 
   # Calc axis breaks
   x_n_breaks <- axis_breaks(dat[[x]])

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -500,7 +500,7 @@ cohort_line <- function(
 reference_line <- function(
   plot,
   dat,
-  era = "time",
+  # era = "time",
   label_name,
   reference,
   relative = FALSE,
@@ -517,9 +517,6 @@ reference_line <- function(
     )
   }
 
-  # Rename era arg
-  era_name <- era
-
   # Add geom for ref line
   if (is.null(ref_line_val)) {
     # cli::cli_alert_warning(
@@ -527,25 +524,25 @@ reference_line <- function(
     # )
     plot
   } else {
-    plot +
-      ggplot2::geom_hline(
-        # ggplot2::aes(
-        yintercept = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
-        # ),
-        color = "black",
-        linetype = "dashed"
-      ) +
-      ggplot2::annotate(
-        geom = "text",
-        # TODO: need to change this for general process
-        x = as.numeric(max(dat$year[dat$era == era_name], na.rm = TRUE)), # - as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE))/200,
-        y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
-        label = glue::glue("{label_name}[{reference}]"), # list(bquote(label_name[.(reference)])),
-        parse = TRUE,
-        hjust = 1,
-        vjust = 0,
-        size = 5 # this is not foolproof
-      )
+  plot +
+    ggplot2::geom_hline(
+      # ggplot2::aes(
+      yintercept = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+      # ),
+      color = "black",
+      linetype = "dashed"
+    ) +
+    ggplot2::annotate(
+      geom = "text",
+      # TODO: need to change this for general process
+      x = as.numeric(max(ggplot2::ggplot_build(plot)@data[[2]][["x"]], na.rm = TRUE)), # - as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE))/200,
+      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+      label = glue::glue("{label_name}[{reference}]"), # list(bquote(label_name[.(reference)])),
+      parse = TRUE,
+      hjust = 1,
+      vjust = 0,
+      size = 5 # this is not foolproof
+    )
   }
 }
 

--- a/man/reference_line.Rd
+++ b/man/reference_line.Rd
@@ -7,7 +7,6 @@
 reference_line(
   plot,
   dat,
-  era = "time",
   label_name,
   reference,
   relative = FALSE,
@@ -18,12 +17,6 @@ reference_line(
 \item{plot}{a ggplot2 object where the reference line will be added}
 
 \item{dat}{standard data frame where reference point should be extracted}
-
-\item{era}{A string naming the era of data.
-
-Default: "time"
-
-Options: "early", "time", "fore" (forecast), or NULL (all data)}
 
 \item{label_name}{string of the name of the quantity that users want to
 extract the reference point from}


### PR DESCRIPTION
## Summary

An issue was identified in `plot_spawning_biomass` (and most likely our other plots) when wanting to access specific data. After some investigation, "DERIVED_QUANTITIES" is found in the converted dataset when `era = NULL`; however there was still an issue finishing the plot because `era = NULL` in the reference line results in an error. The issue was identified in #219 

## The fix:

- adjust reference line to take our era and use plot data instead

## Additional changes

- took out a conditional section when era = NULL plotting horizontal break lines (this is doing too much and not needed)

@JoelRice-NOAA could you take a look at this and confirm this is working for you now? The best way to do this is the following:

```
remotes::install_github("nmfs-ost/stockplotr@fix-sb-plt-219")
# using your example file
albacore <- stockplotr::convert_output(output_file)
stockplotr::plot_spawning_biomass(
  dat = albacore,
  era = NULL, # this is a key change
  ref_line = c("target" = 10e6),
  unit_label = "mt",
  scale_amount = 1e6,
  relative = TRUE,
  module = "DERIVED_QUANTITIES"
)
```

This is what I am getting from the example file in stockplotr:
```
plot_spawning_biomass(stockplotr::example_data, era = NULL)
```

<img width="831" height="570" alt="image" src="https://github.com/user-attachments/assets/3fc8766f-ae13-41e9-8cf2-2cc61be28ac4" />
